### PR TITLE
[FoxitReader] Update to 10.1.0.37527

### DIFF
--- a/foxitreader/foxitreader.nuspec
+++ b/foxitreader/foxitreader.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>foxitreader</id>
     <title>Foxit Reader</title>
-    <version>9.7.1.29511</version>
+    <version>10.1.0.37527</version>
     <authors>Foxit Software Incorporated</authors>
     <owners>ComFreek H.AlanStevens</owners>
     <summary>Foxit Reader: The Best PDF Reader</summary>

--- a/foxitreader/tools/chocolateyInstall.no-wrapper.ps1
+++ b/foxitreader/tools/chocolateyInstall.no-wrapper.ps1
@@ -8,8 +8,8 @@ $ErrorActionPreference = 'Stop'
 
 # See the comments in  https://github.com/ComFreek/chocolatey-packages/blob/master/foxitreader/update.ps1
 # on the &language=German part.
-$url32       = 'https://www.foxitsoftware.com/downloads/latest.php?product=Foxit-Reader&platform=Windows&package_type=exe&language=German&version=9.7.1.29511'
-$checksum32  = 'e4a9b37bb101be67b189483eb5190efb09167331f8e57511c3f5ef76d074a1b6'
+$url32       = 'https://www.foxitsoftware.com/downloads/latest.php?product=Foxit-Reader&platform=Windows&package_type=exe&language=German&version=10.1.0.37527'
+$checksum32  = 'ff5c6a5fd616de5268f928016ca1db41a78796c1834c9875ff11745cf37c99c4'
 
 $installationArgs = @{
 	PackageName    = 'foxitreader'

--- a/foxitreader/tools/chocolateyInstall.wrapper.ps1
+++ b/foxitreader/tools/chocolateyInstall.wrapper.ps1
@@ -8,8 +8,8 @@ $ErrorActionPreference = 'Stop'
 
 # See the comments in  https://github.com/ComFreek/chocolatey-packages/blob/master/foxitreader/update.ps1
 # on the &language=German part.
-$url32       = 'https://www.foxitsoftware.com/downloads/latest.php?product=Foxit-Reader&platform=Windows&package_type=exe&language=German&version=9.7.1.29511'
-$checksum32  = 'e4a9b37bb101be67b189483eb5190efb09167331f8e57511c3f5ef76d074a1b6'
+$url32       = 'https://www.foxitsoftware.com/downloads/latest.php?product=Foxit-Reader&platform=Windows&package_type=exe&language=German&version=10.1.0.37527'
+$checksum32  = 'ff5c6a5fd616de5268f928016ca1db41a78796c1834c9875ff11745cf37c99c4'
 
 function Uninstall-PreviousVersion {
 	Write-Output 'Uninstalling previous version...'

--- a/foxitreader/update.ps1
+++ b/foxitreader/update.ps1
@@ -38,12 +38,12 @@ function global:au_SearchReplace {
 
 function global:au_GetLatest {
 	# Query the latest version
-	$uri = 'https://www.foxitsoftware.com/downloads/downloadForm.php?product=Foxit-Reader&language=English&platform=Windows'
+	$uri = 'https://www.foxitsoftware.com/pdf-reader/version-history.html'
 	$page = Invoke-WebRequest -Uri $uri -UserAgent "Update checker of Chocolatey Community Package 'foxitreader'"
 
-	$version = Get-FixedQuerySelectorAll $page "select[name='version'] option:first-child" | Select -First 1 -ExpandProperty value
+	$version = [Regex]::Matches($page.Content, "(?i)<h3[^>]*>Foxit Reader (.*)</h3>").Groups[1].Value
 
-	# The "&language=German' parameter will force the download of "FoxitReader941_L10N_Setup_Prom.exe" containing all available languages.
+	# The "&language=German' parameter will force the download of "FoxitReader101_L10N_Setup_Prom.exe" containing all available languages.
 	$url32 = "https://www.foxitsoftware.com/downloads/latest.php?product=Foxit-Reader&platform=Windows&package_type=exe&language=German&version=$version"
 
 	$actualVersion = $version
@@ -79,21 +79,6 @@ FoxitReader's current version collides with a version used as package fix notati
 	}
 
 	return @{ Url32 = $url32; Version = $version; ActualVersion = $actualVersion }
-}
-
-# Function taken from http://stackoverflow.com/a/37663738 under CC BY-SA 3.0
-# Many thanks to author midnightfreddie: http://stackoverflow.com/users/4844551/midnightfreddie
-function Get-FixedQuerySelectorAll {
-	param (
-		$HtmlWro,
-		$CssSelector
-	)
-	# After assignment, $NodeList will crash powershell if enumerated in any way including Intellisense-completion while coding!
-	$NodeList = $HtmlWro.ParsedHtml.querySelectorAll($CssSelector)
-
-	for ($i = 0; $i -lt $NodeList.length; $i++) {
-		Write-Output $NodeList.item($i)
-	}
 }
 
 Update-Package


### PR DESCRIPTION
Another update came through, and hasn't been picked up by the auto-updater.

Turns out the latest version check is also broken, since the page being checked against no longer exists. I came up with an alternate approach in a separate commit.

Addresses #12.