### PR TITLE
[FoxitReader] Fix autoupdate

### DIFF
--- a/foxitreader/update.ps1
+++ b/foxitreader/update.ps1
@@ -41,7 +41,7 @@ function global:au_GetLatest {
 	$uri = 'https://www.foxitsoftware.com/pdf-reader/version-history.html'
 	$page = Invoke-WebRequest -Uri $uri -UserAgent "Update checker of Chocolatey Community Package 'foxitreader'"
 
-	$version = [Regex]::Matches($page.Content, "(?i)<h3[^>]*>Foxit Reader (.*)</h3>").Groups[1].Value
+	$version = [Regex]::Matches($page.Content, "(?i)<h3[^>]*>(Foxit Reader|Version) (.*)</h3>").Groups[2].Value
 
 	# The "&language=German' parameter will force the download of "FoxitReader101_L10N_Setup_Prom.exe" containing all available languages.
 	$url32 = "https://www.foxitsoftware.com/downloads/latest.php?product=Foxit-Reader&platform=Windows&package_type=exe&language=German&version=$version"


### PR DESCRIPTION
A new version got pushed out about a week ago, but it wasn't picked up by the version check changes I introduced with #13,

It turns out I erroneously assumed the latest version header would be prefixed with "Foxit Reader". The latest version header went back to prefixing with "Version" instead, so I updated the regex pattern to account for this.